### PR TITLE
更新文档内容到 RUYI 包管理 23231211

### DIFF
--- a/docs/zh/ruyi/environments/gnu-generic/index.md
+++ b/docs/zh/ruyi/environments/gnu-generic/index.md
@@ -1,21 +1,28 @@
 # 使用 GNU 上游工具链配置 RISC-V 编译环境
 
-GNU 上游工具链软件包名为 gnu-upstream ， v0.2 最新版本二进制为 gnu-upstream-20231118 ：
+GNU 上游工具链软件包名为 gnu-upstream ， v0.2 最新版本 x86-64 架构二进制为 gnu-upstream-20231212 ， riscv64 架构二进制为 gnu-upstream-20231118 ：
+
+在 x86-64 环境：
+
+```bash
+$ ruyi install slug:gnu-upstream-20231212
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  232M  100  232M    0     0  4215k      0  0:00:56  0:00:56 --:--:-- 5113k
+info: extracting RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz for package gnu-upstream-0.20231212.0
+info: package gnu-upstream-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-upstream-0.20231212.0
+```
+
+slug 可以从 ``ruyi list`` 的输出中获取，且拷贝时应删除 ``slug: gnu-upstream-20231212`` 之间的空格，变为正确的格式 ``slug:gnu-upstream-20231212`` 。
+该命令将调用 ``wget`` 或 ``curl`` 从远端软件源获取软件包 tarball ，解压并安装到用户目录。
+软件包安装目录默认为 ``~/.local/share/ruyi`` ；在 ``XDG_DATA_HOME`` 环境变量被设置时，目录为 ``$XDG_DATA_HOME/ruyi`` 。
+
+在 riscv64 环境：
 
 ```bash
 $ ruyi install slug:gnu-upstream-20231118
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  232M  100  232M    0     0  1936k      0  0:02:02  0:02:02 --:--:-- 1924k
-info: extracting RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz for package gnu-upstream-0.20231118.0
-info: package gnu-upstream-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-upstream-0.20231118.0
 ```
-
-slug 可以从 ``ruyi list`` 的输出中获取，且拷贝时应删除 ``slug: gnu-upstream-20231118`` 之间的空格，变为正确的格式 ``slug:gnu-upstream-20231118`` 。
-该命令将调用 ``wget`` 或 ``curl`` 从远端软件源获取软件包 tarball ，解压并安装到用户目录。
-软件包安装目录默认为 ``~/.local/share/ruyi`` ；在 ``XDG_DATA_HOME`` 环境变量被设置时，目录为 ``$XDG_DATA_HOME/ruyi`` 。
 
 也可以使用如下命令让 RUYI 自动选择最新版本安装，注意所安装的版本可能是 v0.2 以后的未测试版本。
 
@@ -26,8 +33,7 @@ $ ruyi install gnu-upstream
 由预置的 generic 配置建立编译环境：
 
 ```bash
-$ ruyi venv -t slug:gnu-upstream-20231118 generic venv
-ruyi venv -t slug:gnu-upstream-20231118 generic venv
+$ ruyi venv -t slug:gnu-upstream-20231212 generic venv
 info: Creating a Ruyi virtual environment at venv...
 info: The virtual environment is now created.
 
@@ -87,7 +93,7 @@ $ source venv/bin/ruyi-activate
 
 ```bash
 «Ruyi venv» $ riscv64-unknown-linux-gnu-gcc --version
-riscv64-unknown-linux-gnu-gcc (RuyiSDK 20231118 Upstream-Sources) 13.2.0
+riscv64-unknown-linux-gnu-gcc (RuyiSDK 20231212 Upstream-Sources) 13.2.0
 Copyright (C) 2023 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/docs/zh/ruyi/environments/llvm-generic/index.md
+++ b/docs/zh/ruyi/environments/llvm-generic/index.md
@@ -107,4 +107,4 @@ InstalledDir: /home/myon/.local/share/ruyi/binaries/x86_64/llvm-upstream-17.0.5-
 $
 ```
 
-注意：由于 ``clang-cl`` 设计本意是兼容 MSVC ，故在 RUYI 编译环境中，尽管该命令存在，实际上并不被支持。
+注意：由于 ``clang-cl`` 设计本意是兼容 MSVC ，故在 RUYI 编译环境中，尽管该命令存在，实际上并不被支持。该命令将在 0.3 版本移除。

--- a/docs/zh/ruyi/environments/llvm-generic/index.md
+++ b/docs/zh/ruyi/environments/llvm-generic/index.md
@@ -8,21 +8,19 @@ LLVM 上游工具链软件包名为 llvm-upstream ， v0.2 最新版本二进制
 另外尽管 llvm-upstream 在 ``list`` 命令中打印了 slug 信息，但是实际上并不存在该 slug ，故不能指定 slug 安装。
 
 ```bash
-$ ruyi install llvm-upstream slug:gnu-upstream-20231118
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/llvm-17.0.5.ruyi-20231121.amd64.tar.zst to
-/home/myon/.cache/ruyi/distfiles/llvm-17.0.5.ruyi-20231121.amd64.tar.zst
+$ ruyi install llvm-upstream slug:gnu-upstream-20231212
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100  398M  100  398M    0     0  10.7M      0  0:00:36  0:00:36 --:--:-- 11.0M
+100  232M  100  232M    0     0  7108k      0  0:00:33  0:00:33 --:--:-- 6251k
+info: extracting RuyiSDK-20231212-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz for package gnu-upstream-0.20231212.0
+info: package gnu-upstream-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-upstream-0.20231212.0
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/llvm-17.0.5.ruyi-20231121.amd64.tar.zst to /home/myon/.cache/ruyi/distfiles/llvm-17.0.5.ruyi-20231121.amd64.tar.zst
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  398M  100  398M    0     0  4946k      0  0:01:22  0:01:22 --:--:-- 5737k
 info: extracting llvm-17.0.5.ruyi-20231121.amd64.tar.zst for package llvm-upstream-17.0.5-ruyi.20231121
 info: package llvm-upstream-17.0.5-ruyi.20231121 installed to /home/myon/.local/share/ruyi/binaries/x86_64/llvm-upstream-17.0.5-ruyi.20231121
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  232M  100  232M    0     0  10.0M      0  0:00:23  0:00:23 --:--:-- 10.9M
-info: extracting RuyiSDK-20231118-Upstream-Sources-riscv64-unknown-linux-gnu.tar.xz for package gnu-upstream-0.20231118.0
-info: package gnu-upstream-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-upstream-0.20231118.0
 ```
 
 由预置的 generic 配置建立编译环境：

--- a/docs/zh/ruyi/environments/plct-milkv-duo/index.md
+++ b/docs/zh/ruyi/environments/plct-milkv-duo/index.md
@@ -1,22 +1,29 @@
 # 使用 PLCT 工具链配置 Milkv-Duo 编译环境
 
-PLCT 工具链软件包名为 gnu-plct ， v0.2 最新版本二进制为 gnu-plct-20231118 ：
+PLCT 工具链软件包名为 gnu-plct ， v0.2 最新版本 x86-64 架构二进制为 gnu-plct-20231212  ， riscv64 架构二进制为 gnu-plct-20231118 ：
+
+在 x86-64 环境：
+
+```bash
+$ ruyi install slug:gnu-plct-20231212
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  232M  100  232M    0     0  10.4M      0  0:00:22  0:00:22 --:--:-- 11.0M
+info: extracting RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz for package gnu-plct-0.20231212.0
+info: package gnu-plct-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-0.20231212.0
+```
+
+在 riscv64 环境：
 
 ```bash
 $ ruyi install slug:gnu-plct-20231118
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  232M  100  232M    0     0  10.6M      0  0:00:21  0:00:21 --:--:-- 10.9M
-info: extracting RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz for package gnu-plct-0.20231118.0
-info: package gnu-plct-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-0.20231118.0
 ```
 
 由预置的 milkv-duo 配置在 ``./milkv-venv`` 目录建立编译环境：
 
 ```bash
-$ ruyi venv -t slug:gnu-plct-20231118 milkv-duo ./milkv-venv
+$ ruyi venv -t slug:gnu-plct-20231212 milkv-duo ./milkv-venv
 info: Creating a Ruyi virtual environment at milkv-venv...
 info: The virtual environment is now created.
 
@@ -62,7 +69,7 @@ $ . milkv-venv/bin/ruyi-activate
 
 ```bash
 «Ruyi milkv-venv» $ riscv64-plct-linux-gnu-gcc --version
-riscv64-plct-linux-gnu-gcc (RuyiSDK 20231118 PLCT-Sources) 13.1.0
+riscv64-plct-linux-gnu-gcc (RuyiSDK 20231212 PLCT-Sources) 13.1.0
 Copyright (C) 2023 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/docs/zh/ruyi/environments/xthead-sipeed-lpi4a/index.md
+++ b/docs/zh/ruyi/environments/xthead-sipeed-lpi4a/index.md
@@ -1,29 +1,13 @@
 # 使用平头哥工具链配置荔枝派 4A 编译环境
 
 从 ``list profiles`` 的输出可以看到，预置的 sipeed-lpi4a 配置需要支持 xthead 特性的工具链包。
-若指定不支持该特性的工具链建立虚拟环境并不会报错，但是在构建过程中将会报错：
+若指定不支持该特性的工具链建立虚拟环境将会报错：
 
 ```bash
-$ ruyi venv -t slug:gnu-plct-20231118 sipeed-lpi4a venv
-info: Creating a Ruyi virtual environment at venv...
-info: The virtual environment is now created.
-
-You may activate it by sourcing the appropriate activation script in the
-bin directory, and deactivate by invoking `ruyi-deactivate`.
-
-A fresh sysroot/prefix is also provisioned in the virtual environment.
-It is available at the following path:
-
-    /home/myon/ruyisdk/ruyi/venv/sysroot
-
-The virtual environment also comes with ready-made CMake toolchain file
-and Meson cross file. Check the virtual environment root for those;
-comments in the files contain usage instructions.
-
-$ . venv/bin/ruyi-activate
-«Ruyi venv» $ riscv64-plct-linux-gnu-gcc test.c
-cc1: error: '-mcpu=c910': unknown CPU
-cc1: error: unknown cpu 'c910' for '-mtune'
+$ ruyi venv -t slug:gnu-plct-20231212 sipeed-lpi4a venv
+fatal error: the package slug:gnu-plct-20231212 does not support all necessary features for the profile sipeed-lpi4a
+info: feature(s) needed by profile:   xthead
+info: feature(s) provided by package: (none)
 ```
 
 从 ``ruyi list -v`` 中可以看到 gnu-plct-xthead 工具链是支持该特性的：
@@ -33,7 +17,7 @@ $ ruyi list -v
 
 ...
 
-## toolchain/gnu-plct-xthead 0.20231118.0
+## toolchain/gnu-plct-xthead 0.20231212.0
 
 ...
 
@@ -52,23 +36,30 @@ $ ruyi list -v
 
 ```
 
-平头哥工具链软件包名为 gnu-plct-xthead ， v0.2 最新版本二进制为 gnu-plct-xthead-20231118 ：
+平头哥工具链软件包名为 gnu-plct-xthead ， v0.2 最新版本 x86-64 架构二进制为 gnu-plct-xthead-20231212 ， riscv64 架构二进制为 gnu-plct-xthead-20231118 ：
+
+在 x86-64 环境：
+
+```bash
+$ ruyi install slug:gnu-plct-xthead-20231212
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  273M  100  273M    0     0  9864k      0  0:00:28  0:00:28 --:--:-- 10.9M
+info: extracting RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz for package gnu-plct-xthead-0.20231212.0
+info: package gnu-plct-xthead-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-xthead-0.20231212.0
+```
+
+在 riscv64 环境：
 
 ```bash
 $ ruyi install slug:gnu-plct-xthead-20231118
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  273M  100  273M    0     0  10.8M      0  0:00:25  0:00:25 --:--:-- 10.9M
-info: extracting RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz for package gnu-plct-xthead-0.20231118.0
-info: package gnu-plct-xthead-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-xthead-0.20231118.0
 ```
 
 由预置的 sipeed-lpi4a 配置在 ``./sipeed-venv`` 建立编译环境：
 
 ```bash
-$ ruyi venv -t slug:gnu-plct-xthead-20231118 sipeed-lpi4a ./sipeed-venv
+$ ruyi venv -t slug:gnu-plct-xthead-20231212 sipeed-lpi4a ./sipeed-venv
 info: Creating a Ruyi virtual environment at sipeed-venv...
 info: The virtual environment is now created.
 

--- a/docs/zh/ruyi/getstarted/index.md
+++ b/docs/zh/ruyi/getstarted/index.md
@@ -20,16 +20,16 @@ $ sudo apt-get install wget git tar bzip2 xz zstd
 
 从发布[镜像](https://mirror.iscas.ac.cn/ruyisdk/ruyi/testing/)中选择合适架构的预编译二进制下载，当前 RUYI 包管理支持 amd64 和 riscv64 架构编译环境。
 
-v0.2 版本的稳定二进制为 0.2.0-beta.20231207 版本。
+v0.2 版本的稳定二进制为 0.2.0-beta.20231211 版本。
 
 这里以 amd64 架构环境为例进行安装：
 
 ```bash
-$ wget https://mirror.iscas.ac.cn/ruyisdk/ruyi/testing/ruyi.amd64.20231207
-$ chmod +x ./ruyi.amd64.20231207
-$ sudo cp ruyi.amd64.20231207 /usr/local/bin/ruyi
+$ wget https://mirror.iscas.ac.cn/ruyisdk/ruyi/testing/ruyi.amd64.20231211
+$ chmod +x ./ruyi.amd64.20231211
+$ sudo cp ruyi.amd64.20231211 /usr/local/bin/ruyi
 $ ruyi version
-Ruyi 0.2.0-beta.20231207
+Ruyi 0.2.0-beta.20231211
 Copyright (C) 2023 Institute of Software, Chinese Academy of Sciences (ISCAS).
 All rights reserved.
 License: Apache-2.0 <https://www.apache.org/licenses/LICENSE-2.0>
@@ -41,9 +41,8 @@ License: Apache-2.0 <https://www.apache.org/licenses/LICENSE-2.0>
 
 ```bash
 $ ruyi --help
-usage: ruyi [-h] [-V] {extract,install,i,list,update,venv,admin,self,version} ...
 
-RuyiSDK Package Manager 0.2.0-beta.20231207
+RuyiSDK Package Manager 0.2.0-beta.20231211
 
 options:
   -h, --help            show this help message and exit
@@ -88,11 +87,14 @@ List of available packages:
 * emulator/qemu-user-riscv-upstream
   - 8.1.2-ruyi.20231121 (latest)
 * toolchain/gnu-plct
-  - 0.20231118.0 (latest) slug: gnu-plct-20231118
+  - 0.20231212.0 (latest) slug: gnu-plct-20231212
+  - 0.20231118.0 () slug: gnu-plct-20231118
 * toolchain/gnu-plct-xthead
-  - 0.20231118.0 (latest) slug: gnu-plct-xthead-20231118
+  - 0.20231212.0 (latest) slug: gnu-plct-xthead-20231212
+  - 0.20231118.0 () slug: gnu-plct-xthead-20231118
 * toolchain/gnu-upstream
-  - 0.20231118.0 (latest) slug: gnu-upstream-20231118
+  - 0.20231212.0 (latest) slug: gnu-upstream-20231212
+  - 0.20231118.0 () slug: gnu-upstream-20231118
 * toolchain/llvm-upstream
   - 17.0.5-ruyi.20231121 (latest) slug: llvm-upstream-20231121
 ```

--- a/docs/zh/ruyi/index.md
+++ b/docs/zh/ruyi/index.md
@@ -9,7 +9,7 @@ RUYI 包管理是 RuyiSDK 开发中的包管理器。用于管理工具链、模
 + x86_64 Fedora 38
 + x86_64 Ubuntu 22.04 LTS
 + x86_64 openEuler 23.09
-+ riscv64 RevyOS 20231026
++ riscv64 RevyOS 20231210
 + riscv64 openEuler 23.09
 
 ## 命令
@@ -38,6 +38,6 @@ ruyi self uninstall
 ## 外部链接
 
 + [Fedora38 Workstation](https://download.fedoraproject.org/pub/fedora/linux/releases/38/Workstation/x86_64/iso/)
-+ [RevyOS 20231026](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20231026/)
++ [RevyOS 20231210](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20231210/)
 + [Ubuntu 22.04 LTS](https://www.releases.ubuntu.com/jammy/)
 + [openEuler 23.09 Images](https://repo.openeuler.openatom.cn/openEuler-23.09/ISO/)

--- a/docs/zh/ruyi/virtual_machines/qemu-upstream/index.md
+++ b/docs/zh/ruyi/virtual_machines/qemu-upstream/index.md
@@ -1,24 +1,21 @@
 # 使用上游 QEMU 模拟器运行交叉编译的 RISC-V 二进制
 
-这里使用上游工具链配置带 QEMU 支持 RISC-V 编译环境，并使用上游 QEMU 运行构建出的 RISC-V 二进制。
+这里在 x86-64 环境下使用 plct 工具链配置带上游 QEMU 支持 RISC-V 编译环境，并使用 QEMU 运行构建出的 RISC-V 二进制。
 
 ```bash
-$ ruyi install slug:gnu-plct-20231118 qemu-user-riscv-upstream
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/qemu-user-riscv-8.1.2.ruyi-20231121.amd64.tar.zst to
-/home/myon/.cache/ruyi/distfiles/qemu-user-riscv-8.1.2.ruyi-20231121.amd64.tar.zst
+$ ruyi install slug:gnu-plct-20231212 qemu-user-riscv-upstream
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/qemu-user-riscv-8.1.2.ruyi-20231121.amd64.tar.zst to /home/myon/.cache/ruyi/distfiles/qemu-user-riscv-8.1.2.ruyi-20231121.amd64.tar.zst
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100 14.4M  100 14.4M    0     0  7217k      0  0:00:02  0:00:02 --:--:-- 7218k
+100 14.4M  100 14.4M    0     0  9523k      0  0:00:01  0:00:01 --:--:-- 9529k
 info: extracting qemu-user-riscv-8.1.2.ruyi-20231121.amd64.tar.zst for package qemu-user-riscv-upstream-8.1.2-ruyi.20231121
-info: package qemu-user-riscv-upstream-8.1.2-ruyi.20231121 installed to
-/home/myon/.local/share/ruyi/binaries/x86_64/qemu-user-riscv-upstream-8.1.2-ruyi.20231121
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz
+info: package qemu-user-riscv-upstream-8.1.2-ruyi.20231121 installed to /home/myon/.local/share/ruyi/binaries/x86_64/qemu-user-riscv-upstream-8.1.2-ruyi.20231121
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100  232M  100  232M    0     0  10.1M      0  0:00:22  0:00:22 --:--:-- 11.0M
-info: extracting RuyiSDK-20231118-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz for package gnu-plct-0.20231118.0
-info: package gnu-plct-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-0.20231118.0
+100  232M  100  232M    0     0  9380k      0  0:00:25  0:00:25 --:--:-- 8516k
+info: extracting RuyiSDK-20231212-PLCT-Sources-riscv64-plct-linux-gnu.tar.xz for package gnu-plct-0.20231212.0
+info: package gnu-plct-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-0.20231212.0
 ```
 
 建立编译环境：

--- a/docs/zh/ruyi/virtual_machines/qemu-xthead/index.md
+++ b/docs/zh/ruyi/virtual_machines/qemu-xthead/index.md
@@ -1,24 +1,21 @@
 # 使用平头哥 QEMU 模拟器运行交叉编译的 RISC-V 二进制
 
-这里使用平头哥工具链配置带 QEMU 支持的荔枝派 4A 编译环境，并使用平头哥 QEMU 运行构建出的 RISC-V 二进制。
+这里在 x86-64 环境下使用平头哥工具链配置带 QEMU 支持的荔枝派 4A 编译环境，并使用平头哥 QEMU 运行构建出的 RISC-V 二进制。
 
 ```bash
-$ ruyi install slug:gnu-plct-xthead-20231118 qemu-user-riscv-xthead
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/qemu-user-riscv-xthead-6.1.0.ruyi-20231207.amd64.tar.zst to
-/home/myon/.cache/ruyi/distfiles/qemu-user-riscv-xthead-6.1.0.ruyi-20231207.amd64.tar.zst
+$ ruyi install slug:gnu-plct-xthead-20231212 qemu-user-riscv-xthead
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz to /home/myon/.cache/ruyi/distfiles/RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100 3577k  100 3577k    0     0  6110k      0 --:--:-- --:--:-- --:--:-- 6104k
+100  273M  100  273M    0     0  6462k      0  0:00:43  0:00:43 --:--:-- 6180k
+info: extracting RuyiSDK-20231212-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz for package gnu-plct-xthead-0.20231212.0
+info: package gnu-plct-xthead-0.20231212.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-xthead-0.20231212.0
+info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/qemu-user-riscv-xthead-6.1.0.ruyi-20231207.amd64.tar.zst to /home/myon/.cache/ruyi/distfiles/qemu-user-riscv-xthead-6.1.0.ruyi-20231207.amd64.tar.zst
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 3577k  100 3577k    0     0  5226k      0 --:--:-- --:--:-- --:--:-- 5222k
 info: extracting qemu-user-riscv-xthead-6.1.0.ruyi-20231207.amd64.tar.zst for package qemu-user-riscv-xthead-6.1.0-ruyi.20231207+g03813c9fe8
-info: package qemu-user-riscv-xthead-6.1.0-ruyi.20231207+g03813c9fe8 installed to
-/home/myon/.local/share/ruyi/binaries/x86_64/qemu-user-riscv-xthead-6.1.0-ruyi.20231207+g03813c9fe8
-info: downloading https://mirror.iscas.ac.cn/ruyisdk/dist/RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz to
-/home/myon/.cache/ruyi/distfiles/RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  273M  100  273M    0     0  10.2M      0  0:00:26  0:00:26 --:--:-- 10.9M
-info: extracting RuyiSDK-20231118-T-Head-Sources-riscv64-plctxthead-linux-gnu.tar.xz for package gnu-plct-xthead-0.20231118.0
-info: package gnu-plct-xthead-0.20231118.0 installed to /home/myon/.local/share/ruyi/binaries/x86_64/gnu-plct-xthead-0.20231118.0
+info: package qemu-user-riscv-xthead-6.1.0-ruyi.20231207+g03813c9fe8 installed to /home/myon/.local/share/ruyi/binaries/x86_64/qemu-user-riscv-xthead-6.1.0-ruyi.20231207+g03813c9fe8
 ```
 
 建立编译环境：


### PR DESCRIPTION
+ 更新 RUYI 包管理到 23231211 版本
+ 更新测试的 RevyOS 版本到 [20231210](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20231210/)
+ 更新 x86-64 工具链 gnu-upstream 、 gnu-plct 、 gnu-plct-xthead 版本到 20231212
+ 添加 clang-cl 将在 0.3 版本移除的信息
