### PR TITLE
Fix github page deploy

### DIFF
--- a/.github/workflows/gh-page.yaml
+++ b/.github/workflows/gh-page.yaml
@@ -1,0 +1,44 @@
+name: gh-page
+
+on: 
+  push:
+    branches:
+      - zh
+
+permissions: write-all
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: 'ruyisdk/ruyisdk-website'
+
+      - name: Modify website
+        run: |
+          rmdir docs
+          sed -i 's| baseUrl:.*| baseUrl: "/docs/",|' ./docusaurus.config.js
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: './docs'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.4.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
将在 gh-page 分支网站结构和 ruyisdk.org 一样，也就是使用 ruyisdk-website 的框架和 docs 仓库的最新文档进行构建。好处是 docs 仓库的内容在更新到 ruyisdk.org 之前就可以看到效果。

有一个已知问题：使用绝对路径的链接失效。因为 docs 仓库的 Github Page 需要用 https://ruyisdk.github.io/docs 访问， Base URL 从 ``/`` 变成 ``/docs``，但是使用绝对路径的链接并不会随之改变。比如 ``[这里](/docs/Package-Manager/installation)`` 将会跳转到 <https://ruyisdk.github.io/docs/Package-Manager/installation>，而实际可用的链接是 <https://ruyisdk.github.io/docs/docs/Package-Manager/installation>。这本身是浏览器行为，但 docusaurus 在构建时会进行检查，会刷相关的日志，确认链接正确就可以忽略。
