### PR TITLE
Remove info of mirror.iscas.ac.cn/git/ruyisdk/packages-index

### DIFF
--- a/Package-Manager/packages.md
+++ b/Package-Manager/packages.md
@@ -16,14 +16,14 @@ $ ruyi update
 
 ### ``ruyi update`` 拉取失败
 
-由于目前软件包索引信息托管于 GitHub 仓库，若出现仓库访问不稳定的情况，可在配置文件中配置使用 [备用仓库](https://mirror.iscas.ac.cn/git/ruyisdk/packages-index.git)。
+由于目前软件包索引信息托管于 GitHub 仓库，若出现仓库访问不稳定的情况，可在配置文件中配置使用镜像仓库（如有）。
 
 Ruyi 包管理器的配置文件默认存放在 ``~/.config/ruyi/config.toml``，在 ``XDG_CONFIG_HOME`` 被配置的时候为 ``$XDG_CONFIG_HOME/ruyi/config.toml``。文件不存在可以自行建立。
 
 ```
 [repo]
 local = ""
-remote = "https://mirror.iscas.ac.cn/git/ruyisdk/packages-index.git"
+remote = "https://gitee.com/ruyisdk/packages-index.git"
 branch = "main"
 ```
 


### PR DESCRIPTION
该仓库 <https://mirror.iscas.ac.cn/git/ruyisdk/packages-index> 曾用作备用仓库，现已有 4 个月没有同步，且已经出现 [145c1987](https://mirror.iscas.ac.cn/git/ruyisdk/packages-index/-/commit/145c19871577eeb80c3aaa983c9cc11c8c6deb75)、 [7adb2290](https://mirror.iscas.ac.cn/git/ruyisdk/packages-index/-/commit/7adb22908383257ee36360322633828262880afc) 与 [fab774eb](https://mirror.iscas.ac.cn/git/ruyisdk/packages-index/-/commit/fab774eb944720f4801f936cb51757e18ece7735) 三个与 [ruyisdk/packages-index](https://github.com/ruyisdk/packages-index) 相冲突的提交。

故删除与该仓库相关的信息。