### PR TITLE
codeblock: use new codeblock

### DIFF
--- a/IDE/cases/_category_.json
+++ b/IDE/cases/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "使用案例",
+  "label": "IDE 使用案例",
   "position": 2,
   "link": {
     "type": "generated-index",

--- a/IDE/cases/milkv-duo-ide.md
+++ b/IDE/cases/milkv-duo-ide.md
@@ -5,7 +5,7 @@
 1. 安装 RuyiSDK 包管理器 [参考](/docs/Package-Manager/installation)
 2. 安装编译工具链，本文以 `gnu-milkv-milkv-duo-musl` 编译器举例（您可以根据需要修改工具链及版本）：
 
-   ```bash
+   ```bash input="2,5"
    # 查看软件源的资源
    $ ruyi list --name-contains milkv --category-is toolchain
 
@@ -13,11 +13,10 @@
    $ ruyi install gnu-milkv-milkv-duo-musl-bin
 
    # 从返回信息中可以查看安装的路径，如 ~/.local/share/ruyi/binaries/x86_64/gnu-milkv-milkv-duo-musl-bin-0.20240731.0+git.67688c7335e7
-
    ```
 3. 创建和使用Duo编译环境
 
-   ```bash
+   ```bash input="2,5"
    # 查看ruyi预配置环境
    $ ruyi list profiles
 
@@ -31,7 +30,7 @@
 
 本文以 milkv-duo 开发板的应用示例 duo-examples 为例。使用下面任一方式获取源码：
 
-   ```bash
+   ```bash input="2,5"
    # 方法一：git clone
    $ git clone https://github.com/milkv-duo/duo-examples.git
 
@@ -254,12 +253,9 @@ clean:
 1. 下载原厂gdbserver可执行程序：https://github.com/milkv-duo/duo-buildroot-sdk/blob/develop/ramdisk/rootfs/public/gdbserver/riscv_musl/usr/bin/gdbserver
 2. 将上述下载的gdbserver拷贝到milkv duo设备的path路径下：
 
-   ```bash
-
+   ```bash input="1-2"
    $ scp gdbserver root@192.168.42.1:/usr/bin/
-
    $ ssh root@192.168.42.1 "chmod +x /usr/bin/gdbserver"
-
    ```
 
 #### Terminal中调试
@@ -272,14 +268,14 @@ GDBServer + GDB命令远程调试的步骤如下：
 
 1. milkvduo设备端（helloworld所在目录下操作）:
 
-   ```bash
+   ```bash input="1"
    [root@milkv-duo]~/target# gdbserver :2345 ./sumdemo
    Process ./sumdemo created; pid = 1802
    Listening on port 2345
    ```
 2. PC端（helloworld.c所在目录下操作）：
 
-   ```bash
+   ```bash input="1,5-7"
    $ cd ~/ews-milkvduo-t01/sumdemo
 
    # 查看gdb版本，启动调试
@@ -348,7 +344,7 @@ GDBServer + GDB命令远程调试的步骤如下：
 
     2. 将公钥添加到milkv duo上：
 
-```bash
+```bash input="1"
 $ cat ~/.ssh/xxxx.pub | ssh root@192.168.42.1 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
 ```
 

--- a/Package-Manager/_binaryPackages.mdx
+++ b/Package-Manager/_binaryPackages.mdx
@@ -1,7 +1,6 @@
 
 import ReleaseProvider, { DownloadRuyi, ChmodCommand, CpCommand } from '@site/src/components/docs_utils/LatestReleases';
 import ArchSelector from '@site/src/components/docs_utils/LatestReleases/ArchSelector';
-import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 <ReleaseProvider>
   <>
@@ -29,9 +28,9 @@ import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 您可以通过以下方式验证安装是否成功：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi version
-`} />
+```
 
 若命令执行并正常打印了 Copyright 信息则安装已经成功；若出现了非预期的输出则需要检查安装过程和系统环境。
 

--- a/Package-Manager/_linuxPkg.mdx
+++ b/Package-Manager/_linuxPkg.mdx
@@ -1,4 +1,3 @@
-import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 ## 使用系统包管理器安装
 
@@ -9,9 +8,9 @@ import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 从 AUR 安装，以 ``yay`` 为例，注意应当使用普通用户：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ yay -S ruyi
-`} />
+```
 
 从 Arch Linux CN 软件源安装，以 ISCAS 开源镜像站为例添加配置：
 
@@ -22,10 +21,10 @@ Server = https://mirror.iscas.ac.cn/archlinuxcn/$arch
 
 使用 ``pacman`` 安装：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1,2"
 $ sudo pacman -Sy
 $ sudo pacman -S ruyi
-`} />
+```
 
 
 ### Gentoo Linux
@@ -35,24 +34,24 @@ Gentoo Linux 用户可参考以下步骤，通过官方提供的 `ruyisdk-overla
 
 1. 安装 `eselect-repository` 与 Git 客户端：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ sudo emerge --ask app-eselect/eselect-repository dev-vcs/git
-`} />
+```
 
 2. 确保系统已添加主 Gentoo 仓库（通常已默认配置）。
 
 
 3. 使用 `eselect-repository` 添加 `ruyisdk-overlay`
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ sudo eselect repository add ruyisdk git https://github.com/ruyisdk/ruyisdk-overlay.git
-`} />
+```
 
 4. 同步仓库
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ sudo emaint sync -r ruyisdk
-`} />
+```
 
 5. 接受测试关键字（Unmask）
 
@@ -60,26 +59,26 @@ Ruyi 的 ebuild 被标记为测试版本，需要解屏蔽才能安装。
 
     - 首先执行以下命令生成必要的 package.accept_keywords 改动
 
-        <CodeBlock lang="bash" showTitleCopyButton="true" code={`
+        ```bash input="1"
         $ sudo emerge dev-util/ruyi --autounmask-write --autounmask
-        `} />
+        ```
 
     - 运行 `dispatch-conf` ，并在界面中输入 `u`（use-new）接受所有改动。
 
-        <CodeBlock lang="bash" showTitleCopyButton="true" code={`
+        ```bash input="1"
         $ sudo dispatch-conf
-        `} />
+        ```
 
 6. 安装 Ruyi 包管理器
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ sudo emerge --ask dev-util/ruyi
-`} />
+```
 
 7. 验证你的安装
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi version
-`} />
+```
 
 命令应当可以正常运行并打印版本和 Copyright 信息，如果失败请检查系统环境或重新尝试安装。

--- a/Package-Manager/_pythonPip.mdx
+++ b/Package-Manager/_pythonPip.mdx
@@ -1,4 +1,3 @@
-import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 ## 使用 Python 包管理器安装
 > 环境标签： Linux x86_64 arm64
@@ -17,15 +16,15 @@ RuyiSDK 包管理器现已同步发布至 PyPI（[查看 PyPI 页面](https://py
 ### 使用 `pipx` 全局安装
 `pipx` 是一个用于安装 Python CLI 工具的工具，它会将每个包安装到独立的环境中，并自动将可执行文件链接到 `PATH`。
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ pipx install ruyi
-`} />
+```
 
 安装完成后，`ruyi` 命令会自动添加到你的 `PATH` 中，通常位于 `~/.local/bin`，因此可以通过以下命令验证 `ruyi` 是否安装成功：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi version
-`} />
+```
 
 若命令执行并正常打印了 Copyright 信息则安装已经成功。如果出现错误或未找到命令，请检查安装步骤是否正确，并确认环境变量配置是否生效。
 
@@ -33,15 +32,15 @@ $ ruyi version
 ### 在虚拟环境中安装
 如果你希望将 `ruyi` 安装在某个虚拟环境中（例如 `/path/to/some/venv`），参考以下方式在虚拟环境中使用，在使用前请务必将路径替换为您环境的实际路径：
 
-<CodeBlock lang="bash" code={`
+```bash input="3"
 # 使用绝对路径调用命令
 # 注意：请务必将路径替换为您环境中的实际路径
 $ /path/to/some/venv/bin/pip install ruyi
-`} />
+```
 
 此时，`ruyi` 可执行文件会位于虚拟环境的 `bin` 目录下，**不会**自动添加到系统 `PATH`，因此使用时需要使用完整路径调用命令或者先激活虚拟环境：
 
-<CodeBlock lang="bash" code={`
+```bash input="3,7,8"
 # 使用完整路径执行ruyi 
 # 注意：请务必将路径替换为您环境中的实际路径
 $ /path/to/some/venv/bin/ruyi version
@@ -50,7 +49,6 @@ $ /path/to/some/venv/bin/ruyi version
 # 注意：请务必将路径替换为您环境中的实际路径
 $ source /path/to/some/venv/bin/activate
 $ ruyi version
-
-`} />
+```
 
 若命令执行并正常打印了 Copyright 信息则安装已经成功。

--- a/Package-Manager/cases/case1.md
+++ b/Package-Manager/cases/case1.md
@@ -20,20 +20,20 @@ sidebar_position: 1
 
 2. 查看软件仓软件包索引信息
 
-```bash
+```bash input="1"
 $ ruyi list --name-contains gnu-plct --category-is toolchain
 ```
 
 3. 安装 gnu：ruyi install `<package-name>`
 
-```bash
+```bash input="2"
 # 安装适用于 Licheepi 4A 的编译工具链 gnu-plct-xthead 
 $ ruyi install gnu-plct-xthead 
 ```
 
 4. 查看预置编译环境
 
-```bash
+```bash input="1"
 $ ruyi list profiles
 ```
 
@@ -41,7 +41,7 @@ $ ruyi list profiles
    > 注意在虚拟环境创建时，需要指定正确的编译器版本和 sysroot 类型。
    > 在不指定版本号时默认使用的是软件源里的最新版本，而不是本地安装的版本。
 
-```bash
+```bash input="2,5,8,11,14"
 # 使用帮助命令了解使用
 $ ruyi venv -h
 
@@ -60,7 +60,7 @@ $ . venv-sipeed/bin/ruyi-activate
 
 6. 下载解压 coremark 源码作为编译对象
 
-```bash
+```bash input="2,5,8"
 # 创建目录，用于管理解压的源码
 $ mkdir coremark && cd coremark
 
@@ -75,14 +75,14 @@ $ ls -al
 
 7. 设置 coremark 源码中的编译配置信息(参考 coremark 仓库自述文档)
 
-```bash
+```bash input="2"
 # 按照coremark项目build指导修改gcc
 $ sed -i 's/\bgcc\b/riscv64-plctxthead-linux-gnu-gcc/g' linux64/core_portme.mak
 ```
 
 8. 执行交叉编译和构建，得到可执行程序 coremark.exe
 
-```bash
+```bash input="2,4"
 # 执行构建
 $ make PORT_DIR=linux64 link
 
@@ -92,7 +92,7 @@ $ ls -al
 
 9. 查看 riscv64 可执行程序文件属性信息。
 
-```bash
+```bash input="1"
 $ file coremark.exe
 # 命令回显信息显示了文件的架构相关信息
 ```
@@ -101,7 +101,7 @@ $ file coremark.exe
 
 10. 直接运行 riscv64 coremark 可执行程序
 
-```bash
+```bash input="1"
 $ ./coremark.exe
 ```
 

--- a/Package-Manager/cases/case2.md
+++ b/Package-Manager/cases/case2.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 首先进入编译环境：
 
-```bash
+```bash input="2,4,6"
 # 安装编译工具链 gnu-milkv-milkv-duo-musl-bin
 $ ruyi install gnu-milkv-milkv-duo-musl-bin
 # 以 generic profile 创建虚拟环境 milkv-venv
@@ -19,7 +19,7 @@ $ . milkv-venv/bin/ruyi-activate
 
 coremark 源码可以直接从 Ruyi 软件仓库中下载：
 
-```bash
+```bash input="1-3"
 «Ruyi milkv-venv» $ mkdir coremark
 «Ruyi milkv-venv» $ cd coremark
 «Ruyi milkv-venv» $ ruyi extract coremark
@@ -35,13 +35,13 @@ info: package coremark-1.0.1 extracted to current working directory
 
 由于使用的工具链为 ``gnu-milkv-milkv-duo-bin``，查看 bin 文件夹，需要编辑构建脚本：
 
-```bash
+```bash input="1"
 «Ruyi milkv-venv» $ sed -i 's/\bgcc\b/riscv64-unknown-linux-musl-gcc/g' linux64/core_portme.mak
 ```
 
 构建 coremark：
 
-```bash
+```bash input="1,4"
 «Ruyi milkv-venv» $ make PORT_DIR=linux64 LFLAGS_END=-march=rv64gcv0p7xthead link
 riscv64-unknown-linux-musl-gcc -O2 -Ilinux64 -I. -DFLAGS_STR=\""-O2   -march=rv64gcv0p7xthead"\" -DITERATIONS=0  core_list_join.c core_main.c core_matrix.c core_state.c core_util.c linux64/core_portme.c -o ./coremark.exe -march=rv64gcv0p7xthead
 Link performed along with compile
@@ -53,7 +53,7 @@ coremark.exe: ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI, vers
 
 退出虚拟环境
 
-```bash
+```bash input="1"
 «Ruyi milkv-venv» $ ruyi-deactivate
 $
 ```
@@ -62,13 +62,13 @@ $
 
 传送 coremark 二进制的 Milkv Duo， Milkv Duo 的 IP 地址请按实际情况更改。
 
-```bash
+```bash input="1"
 $ scp -O ./coremark.exe root@192.168.42.1:~
 ```
 
 在 Milkv Duo 上运行
 
-```bash
+```bash input="1"
 [root@milkv-duo]~# ./coremark.exe
 2K performance run parameters for coremark.
 CoreMark Size    : 666

--- a/Package-Manager/cases/case3.md
+++ b/Package-Manager/cases/case3.md
@@ -26,7 +26,7 @@ sidebar_position: 3
 
 ruyi 包管理器提供了为 RISC-V 开发板安装操作系统的功能，为任一型号的 RISC-V 开发板安装镜像都只需要执行：
 
-```bash
+```bash input="1"
 $ ruyi device provision
 ```
 

--- a/Package-Manager/cases/case4.md
+++ b/Package-Manager/cases/case4.md
@@ -60,7 +60,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}="1234", ATTR{idProduct}=="8888", MODE="0666", G
 
 ruyi 包管理器提供了为 RISC-V 开发板安装操作系统的功能，为任一型号的 RISC-V 开发板安装镜像都只需要执行：
 
-```bash
+```bash input="1"
 $ ruyi device provision
 ```
 

--- a/Package-Manager/cases/case5.md
+++ b/Package-Manager/cases/case5.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 
 首先确保你有安装 cmake 和 ninja，如果没有安装，可以使用以下命令安装：
 
-```shell
+```bash input="2,4"
 # Ubuntu/Debian
 $ sudo apt-get install cmake ninja-build
 # Fedora
@@ -17,7 +17,7 @@ $ sudo dnf install cmake ninja-build
 
 下载 zlib：
 
-```shell
+```bash input="1-3
 $ wget https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.2.tar.gz
 $ mkdir zlib-ng
 $ cd zlib-ng
@@ -25,7 +25,7 @@ $ cd zlib-ng
 
 安装并激活 gnu-plct 工具链编译：
 
-```shell
+```bash input="1-3"
 $ ruyi install gnu-plct
 $ ruyi venv -t gnu-plct generic venv
 $ . venv/bin/ruyi-activate
@@ -33,7 +33,7 @@ $ . venv/bin/ruyi-activate
 
 解压 zlib：
 
-```shell
+```bash input="1-2"
 $ tar -xf ./zlib-ng-2.2.2.tar.gz
 $ cd zlib-ng-2.2.2
 ```
@@ -41,13 +41,13 @@ $ cd zlib-ng-2.2.2
 使用 cmake 构建 zlib：
 为什么要用这样的参数可以参考 venv 里的 toolchain.riscv64-plct-linux-gnu.cmake 文件
 
-```shell
+```bash input="1-2"
 $ cmake . -G Ninja -DCMAKE_C_COMPILER=riscv64-plct-linux-gnu-gcc -DZLIB_COMPAT=ON -DWITH_GTEST=OFF
 $ ninja
 ```
 
 检查编译出的文件：
-```shell
+```bash inpupt="1"
 $ file libz.so.1.3.1.zlib-ng 
 libz.so.1.3.1.zlib-ng: ELF 64-bit LSB shared object, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, BuildID[sha1]=bb6bdf59fa0fd746b3a6d3586ff1cfabcbe4a6e9, with debug_info, not stripped
 ```
@@ -56,7 +56,7 @@ libz.so.1.3.1.zlib-ng: ELF 64-bit LSB shared object, UCB RISC-V, RVC, double-flo
 
 安装 meson：
 
-```shell
+```bash input="2,4"
 # Ubuntu/Debian
 $ sudo apt-get install meson
 # Fedora
@@ -65,7 +65,7 @@ $ sudo dnf install meson
 
 和上文一样，首先安装并激活 gnu-plct 工具链编译：
 
-```shell
+```bash input="1-3"
 $ ruyi install gnu-plct
 $ ruyi venv -t gnu-plct generic venv
 $ . venv/bin/ruyi-activate
@@ -73,21 +73,21 @@ $ . venv/bin/ruyi-activate
 
 下载 taisei：
 
-```shell
+```bash input="1-2"
 $ git clone --recurse-submodules --depth=1 https://github.com/taisei-project/taisei
 $ cd taisei
 ```
 
 根据 venv/meson-cross.ini，meson 的交叉编译配置及编译如下：
 
-```shell
+```bash input="1-2"
 $ meson setup --cross-file /home/cyan/zlib-ng/venv/meson-cross.ini build/
 $ meson compile -C build/
 ```
 
 检查编译出的文件：
 
-```shell
+```bash input="1"
 $ file build/src/taisei
 taisei: ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=8fb80413e4a41ffeb75450b80a4b068c504b152e, for GNU/Linux 4.15.0, with debug_info, not stripped
 ```

--- a/Package-Manager/cases/case6.md
+++ b/Package-Manager/cases/case6.md
@@ -7,18 +7,18 @@ sidebar_position: 6
 本案例基于 [为 MilkV Duo 构建 Coremark](case2.md)
 
 首先安装必要的依赖：
-```shell
+```bash input="1"
 $ ruyi install llvm-upstream gnu-plct qemu-user-riscv-upstream
 ```
 
 创建虚拟环境并激活：
-```shell
+```bash input="1-2"
 $ ruyi venv -t llvm-upstream --sysroot-from gnu-plct -e qemu-user-riscv-upstream generic venv
 $ . venv/bin/ruyi-activate
 ```
 
 解包出 coremark 并编译：
-```shell
+```bash input="1-3,5-6"
 «Ruyi milkv-venv» $ mkdir coremark
 «Ruyi milkv-venv» $ cd coremark
 «Ruyi milkv-venv» $ ruyi extract coremark
@@ -28,7 +28,7 @@ $ . venv/bin/ruyi-activate
 ```
 
 这时通过 qemu 运行 coremark：
-```shell
+```bash input="1"
 $ ruyi-qemu coremark.exe
 2K performance run parameters for coremark.
 CoreMark Size    : 666

--- a/Package-Manager/cases/case7.md
+++ b/Package-Manager/cases/case7.md
@@ -6,12 +6,12 @@ sidebar_position: 7
 
 首先安装必要的依赖：
 
-```shell
+```bash input="1"
 $ ruyi install gnu-milkv-milkv-duo-musl-bin
 ```
 
 解包出 milkv-duo-examples 并编译：
-```shell
+```bash input="1-3"
 $ mkdir test-duo-examples
 $ cd test-duo-examples
 $ ruyi extract milkv-duo-examples
@@ -132,13 +132,13 @@ print_info "Environment is ready."
 
 启动虚拟环境：
 
-```shell
+```bash input="1"
 $ source envsetup.sh
 ```
 
 应当可以正常构建：
 
-```shell
+```bash input="1-2"
 $ cd i2c/ssd1306_i2c
 $ make
 ```

--- a/Package-Manager/installation.mdx
+++ b/Package-Manager/installation.mdx
@@ -54,6 +54,6 @@ import PythonPipContent from './\_pythonPip.mdx';
 
 列出帮助信息：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi --help
-`} />
+```

--- a/Package-Manager/intergration.mdx
+++ b/Package-Manager/intergration.mdx
@@ -24,14 +24,14 @@ Ruyi 包管理器工具的 ``venv`` 命令用于组合工具链、模拟器来�
 
 Ruyi 软件源中已经提供了一些预置的配置且无需安装，这些配置可以使用 ``ruyi list profiles`` 命令列出：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi list profiles
 generic
 baremetal-rv64ilp32 (needs flavor(s): {'rv64ilp32'})
 xiangshan-nanhu
 sipeed-lpi4a (needs flavor(s): {'xthead'})
 milkv-duo
-`} />
+```
 
 一些配置需要支持特定 flavor(s) 的 Ruyi 工具链包才能使用，您可以在 ``ruyi list --verbose`` 中查看某个工具链包是否支持这种特性。或者，直接参考“工具链与预制配置组合“中的表格。
 
@@ -64,12 +64,12 @@ Ruyi 包管理在建立虚拟环境之前会检查该环境是否存在冲突，
 
 使用 ``venv`` 命令的具体方法可通过 ``-h`` 参数获得：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi venv -h
-`} />
+```
 这里给出一些实例：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="2,5,8,11,14,17,20,23"
 # 使用 GNU 上游工具链配置 RISC-V 虚拟环境：
 $ ruyi venv -t gnu-upstream generic ./generic-venv
 
@@ -93,7 +93,7 @@ $ ruyi venv -t gnu-plct-xthead sipeed-lpi4a -e qemu-user-riscv-xthead ./xthead-q
 
 # 多工具链示例，其中 gnu-upstream 提供了 sysroot
 $ ruyi venv -t llvm-upstream -t gnu-upstream generic ./upstream-venv
-`} />
+```
 
 虚拟环境是用于集成工具链、模拟器等工具的，创建编译环境之前请确保对应的 Ruyi 软件包已经安装。
 
@@ -103,29 +103,29 @@ $ ruyi venv -t llvm-upstream -t gnu-upstream generic ./upstream-venv
 
 首先安装本示例所需的软件包：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi install gnu-upstream qemu-user-riscv-upstream
-`} />
+```
 
 建立一个干净的目录用于运行用例：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1-2"
 $ mkdir hello-ruyi
 $ cd hello-ruyi
-`} />
+```
 
 获取 ruyisdk-demo 源码：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1-3"
 $ ruyi extract ruyisdk-demo
 $ cd ruyisdk-demo-0.20231114.0
 $ ls
 README.md  rvv-autovec
-`} />
+```
 
 建立虚拟环境：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi venv -t gnu-upstream -e qemu-user-riscv-upstream generic ./myhone-venv
 info: Creating a Ruyi virtual environment at myhone-venv...
 info: The virtual environment is now created.
@@ -141,26 +141,26 @@ It is available at the following path:
 The virtual environment also comes with ready-made CMake toolchain file
 and Meson cross file. Check the virtual environment root for those;
 comments in the files contain usage instructions.
-`} />
+```
 
 该虚拟环境集成了 gnu-upstream 工具链和 qemu-user-riscv-upstream 模拟器，使用目标 riscv64 Linux 操作系统的 generic 配置，将编译环境建立在 ``./myhome-venv`` 目录下（亦可用绝对路径）。命令的输出给出了激活编译环境的方法，退出编译环境的命令， sysroot 目录的绝对路径以及一些其他信息。
 
 在虚拟环境目录可以看到编译环境相关的文件：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ls ./myhone-venv/
 bin                                        ruyi-venv.toml
 binfmt.conf                                sysroot
 meson-cross.ini                            sysroot.riscv64-unknown-linux-gnu
 meson-cross.riscv64-unknown-linux-gnu.ini  toolchain.cmake
 ruyi-cache.v1.toml                         toolchain.riscv64-unknown-linux-gnu.cmake
-`} />
+```
 
 其中 ``binfmt.conf`` 是可用于 systemd-binfmt 的示例配置， ``toolchain.cmake`` 和 ``meson-cross.ini`` 可用于项目的交叉编译， ``sysroot`` 为该虚拟环境使用的 sysroot， ``bin`` 目录包含了该编译环境可用的命令和脚本。
 
 在 ``bin`` 目录下可以查看到可用的工具链二进制：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ls ./myhone-venv/bin/
 riscv64-unknown-linux-gnu-addr2line  riscv64-unknown-linux-gnu-gcc-ranlib     riscv64-unknown-linux-gnu-nm
 riscv64-unknown-linux-gnu-ar         riscv64-unknown-linux-gnu-gcov           riscv64-unknown-linux-gnu-objcopy
@@ -174,20 +174,20 @@ riscv64-unknown-linux-gnu-g++        riscv64-unknown-linux-gnu-ld             ru
 riscv64-unknown-linux-gnu-gcc        riscv64-unknown-linux-gnu-ld.bfd         ruyi-qemu
 riscv64-unknown-linux-gnu-gcc-ar     riscv64-unknown-linux-gnu-ldd
 riscv64-unknown-linux-gnu-gcc-nm     riscv64-unknown-linux-gnu-lto-dump
-`} />
+```
 
 其中包含了全部的工具链命令，被重命名为 ``ruyi-qemu`` 的 QEMU 用户态模拟器，以及用于进入虚拟环境的 ``ruyi-activate`` 脚本。其中工具链命令实际上是指向 ruyi 的软链接。
 
 ``source`` ruyi-activate 脚本即可激活构建环境， ``PS1`` 将被修改：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ source ./myhone-venv/bin/ruyi-activate
 «Ruyi myhone-venv» $
-`} />
+```
 
 同时 ``PATH`` 也被修改，现在可以直接调用工具链了：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1,3"
 «Ruyi myhone-venv» $ whereis riscv64-unknown-linux-gnu-gcc
 riscv64-unknown-linux-gnu-gcc: /home/myhone/hello-ruyi/myhone-venv/bin/riscv64-unknown-linux-gnu-gcc
 «Ruyi myhone-venv» $ riscv64-unknown-linux-gnu-gcc --version
@@ -195,23 +195,23 @@ riscv64-unknown-linux-gnu-gcc (RuyiSDK 20231212 Upstream-Sources) 13.2.0
 Copyright (C) 2023 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-`} />
+```
 
 在 Ruyi 虚拟环境下，除了会自动向工具链传入配置的架构选项外，工具链和模拟器的使用并没有太大的区别。更多内容还可以参考“使用案例”章节。
 
 构建 ruyisdk-demo：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1,2"
 $ cd rvv-autovec
 $ make
-`} />
+```
 
 在完成虚拟环境的使用后，退出编译环境，一切都将被还原到进入以前的状态：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 «Ruyi myhone-venv» $ ruyi-deactivate
 $
-`} />
+```
 
 ## Ruyi 镜像集成
 
@@ -219,9 +219,9 @@ Ruyi 的镜像集成提供了开发板镜像刷写和单片机设备文档。该
 
 该功能提供了一个向导，支持使用 ``dd`` 和 ``fastboot`` 对 RISC-V 设备进行系统镜像刷写，同时也为 RISC-V 单片机这类不能常规刷写的设备提供了指导文档。
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi device provision
-`} />
+```
 
 更详细的示例还可以参考“使用案例”章节。
 

--- a/Package-Manager/misc.mdx
+++ b/Package-Manager/misc.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 6
 ---
 
-import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
-
 # 更多信息
 
 ## 更新 Ruyi 包管理器
@@ -12,9 +10,9 @@ import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
 
 如果您使用系统包管理器安装 Ruyi 包管理器，则可以直接使用系统包管理器升级：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ sudo pacman -Syuu
-`} />
+```
 
 这个命令将在 Arch Linux 执行全面的升级，注意 Arch Linux 并不支持部分升级。
 
@@ -24,35 +22,35 @@ $ sudo pacman -Syuu
 
 如果您使用预编译的单二进制安装 Ruyi 包管理器，可以使用下面的命令卸载 ruyi 包管理器：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self uninstall
-`} />
+```
 
 这个命令将会询问以二次确认该操作，如果希望 Ruyi 包管理不询问而直接执行：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self uninstall -y
-`} />
+```
 
 上面的命令只是删除 Ruyi 包管理器本身，如果希望删除所有缓存和安装了的软件包以实现干净的卸载：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self uninstall --purge
-`} />
+```
 
 同样的，这个命令将会询问以二次确认该操作，如果希望 Ruyi 包管理不询问而直接执行：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self uninstall --purge -y
-`} />
+```
 
 Ruyi 包管理被设计为避免进行需要超级用户权限的操作，如果 Ruyi 包管理器被安装在 ``/usr/local/bin/`` 等需要超级用户权限才能更改的目录下， ``ruyi self uninstall`` 命令将会失败。
 
 此时您可以手动删除所有缓存和安装了的软件包（它们被安装在家目录故不需要超级用户权限来删除）：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self clean --all
-`} />
+```
 
 然后手动删除 Ruyi 包管理器本体。
 

--- a/Package-Manager/packages.mdx
+++ b/Package-Manager/packages.mdx
@@ -2,17 +2,15 @@
 sidebar_position: 3
 ---
 
-import CodeBlock from '@site/src/components/docs_utils/CodeBlock';
-
 # 管理 Ruyi 软件包
 
 ## 刷新本地软件包缓存
 
 获取远程软件源的内容并刷新本地软件包缓存，默认使用托管在 GitHub 上的镜像：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi update
-`} />
+```
 
 软件包缓存将存放在用户目录中，通常为 ``~/.cache/ruyi/packages-index/`` ；在 ``XDG_CACHE_HOME`` 环境变量被设置时，目录为 ``$XDG_CACHE_HOME/ruyi/packages-index/`` 。
 
@@ -20,7 +18,7 @@ $ ruyi update
 
 由于目前软件包索引信息托管于 GitHub 仓库，若出现仓库访问不稳定的情况，可以使用 `ruyi config` 子命令来配置使用[备用仓库](https://mirror.iscas.ac.cn/git/ruyisdk/packages-index.git)。
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="2,5,8,11,14"
 # 查看当前仓库配置
 $ ruyi config get repo.remote
 
@@ -35,7 +33,7 @@ $ ruyi config set repo.local /your/custom/cache/path
 
 # 配置修改完成后，重新刷新本地软件包缓存
 $ ruyi update
-`} />
+```
 
 ## 阅读新闻
 
@@ -45,7 +43,7 @@ $ ruyi update
 
 您可以使用下面的命令来浏览、阅读新闻和标记已读：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input=""
 $ ruyi news list -h
 $ ruyi news list
 $ ruyi news list --new        # 仅列出未读新闻
@@ -54,7 +52,7 @@ $ ruyi news read -h
 $ ruyi news read 1            # 阅读序号（ID）为 1 的新闻
 $ ruyi news read              # 阅读全部未读新闻
 $ ruyi news read --quiet      # 不输出任何东西，只标记未读新闻为已读
-`} />
+```
 
 Ruyi 通过在 ``~/.local/state/ruyi/news.read.txt`` 中存储新闻标题来标记已读新闻，在 ``XDG_STATE_HOME`` 被配置时文件路径为 ``$XDG_STATE_HOME/ruyi/news.read.txt``。
 
@@ -79,7 +77,7 @@ Ruyi 软件包大致分为几个分区：
 
 这是在 ``x86_64`` 机器上的一个示例，实际的列表会更长：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi list --name-contains ''
 List of available packages:
 
@@ -119,7 +117,7 @@ List of available packages:
 * extra/wps-office
   - 12.1.0-r.17900 (latest)
   - 12.1.0-r.17885 ()
-`} />
+```
 
 ``list`` 命令还提供了 ``--verbose`` 或 ``-v`` 参数来输出更详细的信息，这将会打印软件源中几乎所有信息。由于全部输出将会很长，建议给 ``--name-contains`` 传入非空的查找字段，或添加其他限定参数，或将完整输出重定向到文件或 ``less`` 等工具。
 
@@ -143,7 +141,7 @@ List of available packages:
 
 如果您确实需要安装一个预发布版本，可以在配置文件中添加配置：
 
-```
+```ini
 [packages]
 prereleases = true
 ```
@@ -156,9 +154,9 @@ prereleases = true
 
 此时可以指定安装某个架构的二进制软件包：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi install --host x86_64 wps-office
-`} />
+```
 
 ## 安装二进制软件包
 
@@ -172,31 +170,31 @@ $ ruyi install --host x86_64 wps-office
 
 这些软件包可以使用 ``install`` 命令安装，如安装 GNU 上游 gcc 工具链：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input=""
 $ ruyi install gnu-upstream
 $ ruyi install toolchain/gnu-upstream
-`} />
+```
 
 上述通过指定软件包名安装的方式默认会安装标记为 latest 版本的 gnu-upstream 包，如果想安装某个历史版本的 gnu-upstream，则可以通过指定版本来安装：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input=""
 $ ruyi install 'gnu-upstream(0.20231118.0)'
 $ ruyi install 'gnu-upstream(>=0.20231118.0)'
-`} />
+```
 
 表达式支持 ``<``、 ``>``、``==``、 ``<=``、 ``>=``、 ``!=`` 运算符。
 
 如果希望安装多个包：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input=""
 $ ruyi install gnu-plct gnu-upsteam llvm-plct llvm-upstream
-`} />
+```
 
 在一些特殊情况下，如错误删除了已安装软件包的文件，则可以重新安装这个软件包来恢复：
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input=""
 $ ruyi install --reinstall gnu-upstream
-`} />
+```
 
 包管理器下载的包存放在 ``~/.cache/ruyi/distfiles/`` 下，在 ``XDG_CACHE_HOME`` 被指定时为 ``$XDG_CACHE_HOME/ruyi/distfiles/``。这些包通常以已压缩的格式存在，需要调用系统工具解包。在系统中缺少对应的工具时将打印相应的警告。
 
@@ -212,32 +210,32 @@ $ ruyi install --reinstall gnu-upstream
 
 源码包可以使用 ``extract`` 命令下载一个源码包并解包。默认情况下,``extract`` 会将所请求的软件包内容解压到以软件包名、版本命名的独立目录下:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1-3"
 $ ruyi extract ruyisdk-demo
 $ cd ruyisdk-demo-0.20231114.0
 $ ls
 README.md  rvv-autovec
-`} />
+```
 
 如果您需要直接解压到当前工作目录(先前版本的默认行为),可以使用 ``--extract-without-subdir`` 选项:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1-2"
 $ ruyi extract --extract-without-subdir ruyisdk-demo
 $ ls
 README.md  rvv-autovec
-`} />
+```
 
 如果您需要将内容解压到其他目录,可以使用 ``--dest-dir`` 或 ``-d`` 选项指定目标目录:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi extract -d /path/to/destination ruyisdk-demo
-`} />
+```
 
 如果您只需要下载源码包但不解压,可以使用 ``--fetch-only`` 或 ``-f`` 选项:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi extract -f ruyisdk-demo
-`} />
+```
 
 ``extract`` 命令支持和 ``install`` 相同的版本表达方式。
 
@@ -245,22 +243,22 @@ $ ruyi extract -f ruyisdk-demo
 
 您可以使用 ``ruyi uninstall`` 命令卸载已安装的软件包:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi uninstall gnu-upstream
-`} />
+```
 
 该命令还有更简短的别名 ``ruyi remove`` 或 ``ruyi rm`` 可用:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1,2"
 $ ruyi remove gnu-upstream
 $ ruyi rm gnu-upstream
-`} />
+```
 
 如果您需要删除所有已经下载和安装的软件包，可以使用如下命令:
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="1"
 $ ruyi self clean --distfiles --installed-pkgs
-`} />
+```
 
 注意，如果某个工具链软件包被删除，已经建立的依赖该包的虚拟环境将失效，且激活该编译环境时并不会有相关警告。
 

--- a/k230d/intro.mdx
+++ b/k230d/intro.mdx
@@ -41,11 +41,11 @@ output/k230d_canmv_lp64_defconfig/images/sysimage-sdcard.img
 
 构建完成后，请解压文件，刻录到 TF 卡，将 TF 卡插入设备，设备上电即可开始使用。
 
-<CodeBlock lang="bash" showTitleCopyButton="true" code={`
+```bash input="3"
 # 假设/dev/sdb就是TF卡设备节点，执行如下命令烧录TF卡：
 
 $ sudo dd if=sysimage-sdcard.img of=/dev/sdb bs=1M oflag=sync
-`} />
+```
 
 ## 启动
 


### PR DESCRIPTION
## Summary by Sourcery

Replace the custom CodeBlock component with standard MDX fenced code blocks across all documentation, removing unnecessary imports and updating code examples to use language and input attributes.

Enhancements:
- Switch all <CodeBlock> examples to ``` code fences with appropriate lang and input parameters
- Remove CodeBlock imports from MDX files after migrating to the new fenced code syntax