### PR TITLE
docs: update pipx installation venv issue

### DIFF
--- a/Package-Manager/_pythonPip.mdx
+++ b/Package-Manager/_pythonPip.mdx
@@ -20,6 +20,8 @@ RuyiSDK 包管理器现已同步发布至 PyPI（[查看 PyPI 页面](https://py
 $ pipx install ruyi
 ```
 
+当前版本 ruyi 在使用 ``pipx`` 安装时无法支持虚拟环境的完整功能，建议优先使用其他方法安装。
+
 安装完成后，`ruyi` 命令会自动添加到你的 `PATH` 中，通常位于 `~/.local/bin`，因此可以通过以下命令验证 `ruyi` 是否安装成功：
 
 ```bash input="1"


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document current limitations of pipx-based ruyi installation regarding full virtual environment support and recommend alternative installation methods.